### PR TITLE
Support new experience controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 https://github.com/1ForeverHD/TopbarPlus
 
-## Latest 2.10
+## Latest 2.11
 
 Main changes: 
-- Updated meta files to work with wally: 
-  - Changed `default.project.json` to match expected package behavior.
-   - Added `wally.toml`. 
-- Removed "Action Required" callout in favor of a documented `Icon.setVoiceChatEnabled()` function.
+- Changed general design to match new Roblox topbar
+- Removed the Roblox Voice Chat GUI offset
 
 
 ### Documentation
@@ -20,19 +18,5 @@ Import via wally using
 
 ```toml   
 [dependencies]
-Icon = "bebopdevelopmentstudios/topbarplus@2.10.0"
-```
-
-### Config
-
-To offset the topbar to create space for the Roblox Voice Chat GUI, use 
-```lua
-Icon = require("path")
-
---  staticmethod
-Icon.setVoiceChatEnabled(boolean) 
-
--- alternatively, you can directly access IconController
-IconController = require(Icon.IconController)
-IconController.voiceChatEnabled = boolean
+Icon = "bebopdevelopmentstudios/topbarplus@2.11.0"
 ```

--- a/aftman.toml
+++ b/aftman.toml
@@ -3,6 +3,5 @@
 
 # To add a new tool, add an entry to this table.
 [tools]
-rojo = "rojo-rbx/rojo@7.2.1"
+rojo = "rojo-rbx/rojo@7.3.0"
 wally = "upliftgames/wally@0.3.2"
-# rojo = "rojo-rbx/rojo@6.2.0"

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,3 @@
 [tools]
-rojo = { source = "rojo-rbx/rojo", version = "6.0.2" }
+rojo = { source = "rojo-rbx/rojo", version = "7.3.0" }
 tarmac = { source = "rojo-rbx/tarmac", version = "0.4.0" }

--- a/src/Icon/IconController.lua
+++ b/src/Icon/IconController.lua
@@ -466,6 +466,7 @@ function IconController.updateTopbar()
 					break
 				end
 			else
+				-- if true then return end
 				-- if not workspace.handleOverflow.Value then return end
 				--Gets the width of the icon, accounting for its left/right offset.
 				local function getSizeX(iconToCheck, usePrevious)
@@ -503,7 +504,7 @@ function IconController.updateTopbar()
 				end
 
 				local newOverflowIconBoundaryX = getAbsoluteBoundaryX(overflowIcon, oppositeAlignment)
-				local availableSpace = math.abs(boundaryX - newOverflowIconBoundaryX) - (alignmentGap * 2) - 20
+				local availableSpace = math.abs(boundaryX - newOverflowIconBoundaryX) - (alignmentGap * 2)
 				local winningOverlappedIconSizeX = getSizeX(winningOverlappedIcon, true)
 
 				local noLongerExceeds = winningOverlappedIconSizeX < availableSpace

--- a/src/Icon/IconController.lua
+++ b/src/Icon/IconController.lua
@@ -66,18 +66,10 @@ local alignmentDetails = {}
 alignmentDetails["left"] = {
 	startScale = 0,
 	getOffset = function()
-		local offset = 48 + IconController.leftOffset
+		local offset = IconController.leftOffset
 		if checkTopbarEnabled() then
-			local chatEnabled = starterGui:GetCoreGuiEnabled("Chat")
-			if chatEnabled then
-				offset += 12 + 32
-			end
 			if voiceChatIsEnabledForUserAndWithinExperience and not isStudio then
-				if chatEnabled then
-					offset += 67
-				else
-					offset += 43
-				end
+				offset += 43
 			end
 		end
 		return offset

--- a/src/Icon/IconController.lua
+++ b/src/Icon/IconController.lua
@@ -105,7 +105,7 @@ alignmentDetails["mid"] = {
 alignmentDetails["right"] = {
 	startScale = 1,
 	getOffset = function()
-		local offset = IconController.rightOffset --+ getOffsetForTopbarInset()
+		local offset = IconController.rightOffset
 		return offset
 	end,
 	getStartOffset = function(totalIconX)
@@ -113,7 +113,6 @@ alignmentDetails["right"] = {
 		return startOffset
 	end,
 	records = {}
-	--reverseSort = true
 }
 
 
@@ -334,7 +333,6 @@ function IconController.updateTopbar()
 				end
 				offsetX = offsetX + increment
 				otherIcon.targetPosition = UDim2.new(0, (newPositon.X.Scale*topbarSize) + newPositon.X.Offset, 0, (newPositon.Y.Scale*viewportSize.Y) + newPositon.Y.Offset)
-				-- print(otherIcon.name, otherIcon.targetPosition.X.Offset)
 			end
 		end
 
@@ -348,7 +346,7 @@ function IconController.updateTopbar()
 			local sizeX = currentSize.X.Offset
 			local extendLeft, extendRight = IconController.getMenuOffset(iconToCheck)
 			local boundaryXOffset = (side == "left" and (-additionalGap - extendLeft)) or (side == "right" and sizeX + additionalGap + extendRight)
-			local boundaryX = iconToCheck.targetPosition.X.Offset + boundaryXOffset + (topbarStart)
+			local boundaryX = iconToCheck.targetPosition.X.Offset + boundaryXOffset + topbarStart
 			return boundaryX
 		end
 
@@ -362,7 +360,6 @@ function IconController.updateTopbar()
 			end
 
 			local exceededCriticalBoundary = false
-
 			local overflowIconBoundaryX = getAbsoluteBoundaryX(overflowIcon, alignment)
 
 			if overflowIcon.enabled then
@@ -374,7 +371,6 @@ function IconController.updateTopbar()
 					or (alignment == "right" and overflowIconBoundaryX < boundary)
 			end
 
-			-- TODO: what about middle?
 			local boundaryX = alignment == "left" and topbarStart + topbarSize or topbarStart
 			exceededCriticalBoundary = checkExceeds(boundaryX)
 
@@ -398,13 +394,11 @@ function IconController.updateTopbar()
 						additionalMyX = START_LEEWAY
 					end
 					local endIconBoundaryX = getAbsoluteBoundaryX(endIcon, alignment, additionalMyX)
-					-- local isNowClosest = (alignment == "left" and endIconBoundaryX < boundaryX) or (alignment == "right" and endIconBoundaryX > boundaryX)
 					local isNowClosest = (alignment == "left" and endIconBoundaryX < boundaryX) or (alignment == "right" and boundaryX < endIconBoundaryX)
 
 					if not isNowClosest then
 						continue
 					end
-					-- boundaryX = endIconBoundaryX
 					boundaryX = endIconBoundaryX
 					if checkExceeds(endIconBoundaryX) then
 						exceededCriticalBoundary = true
@@ -440,7 +434,7 @@ function IconController.updateTopbar()
 						local yPos = overflowContainer.Position.Y
 						local appearXAdditional = (alignment == "left" and -overflowContainer.Size.X.Offset) or 0
 						local appearX = getAbsoluteBoundaryX(endIcon, oppositeAlignment, appearXAdditional)
-						overflowContainer.Position = UDim2.new(0, appearX, yPos.Scale, yPos.Offset)
+						overflowContainer.Position = UDim2.new(0, appearX - topbarStart, yPos.Scale, yPos.Offset)
 						overflowIcon:setEnabled(true)
 					end
 					if #endIcon.dropdownIcons > 0 then
@@ -505,23 +499,13 @@ function IconController.updateTopbar()
 				end
 
 				if not winningOverlappedIcon then
-					-- print(alignment, "no winning overlapped icon")
 					return
 				end
 
-
-
 				local newOverflowIconBoundaryX = getAbsoluteBoundaryX(overflowIcon, oppositeAlignment)
-				local availableSpace = math.abs(boundaryX - newOverflowIconBoundaryX) - (alignmentGap * 2)
-
+				local availableSpace = math.abs(boundaryX - newOverflowIconBoundaryX) - (alignmentGap * 2) - 20
 				local winningOverlappedIconSizeX = getSizeX(winningOverlappedIcon, true)
 
-				-- if winningOverlappedIconSizeX < 1 then
-				-- 	-- print(alignment, "winningOverlappedIconSizeX == 0")
-				-- 	return
-				-- end
-
-				-- print(winningOverlappedIcon.name, winningOverlappedIconSizeX, availableSpace)
 				local noLongerExceeds = winningOverlappedIconSizeX < availableSpace
 				if not noLongerExceeds then
 					return
@@ -536,7 +520,6 @@ function IconController.updateTopbar()
 				winningOverlappedIcon:leave()
 				winningOverlappedIcon.wasHoveringBeforeOverflow = nil
 
-				-- print(winningOverlappedIcon.name, winningOverlappedIcon._overflowConvertedToMenu)
 				if winningOverlappedIcon._overflowConvertedToMenu then
 					winningOverlappedIcon._overflowConvertedToMenu = nil
 					local iconsToConvert = {}
@@ -560,6 +543,7 @@ function IconController.updateTopbar()
 			requestedTopbarUpdate = false
 			IconController.updateTopbar()
 		end
+
 		return true
 	end)
 	return true

--- a/src/Icon/IconController.lua
+++ b/src/Icon/IconController.lua
@@ -42,7 +42,7 @@ local function checkTopbarEnabled()
 		return starterGui:GetCore("TopbarEnabled")
 	end,function(err)
 		--has not been registered yet, but default is that is enabled
-		return true	
+		return true
 	end)
 	return (success and bool)
 end
@@ -94,7 +94,7 @@ alignmentDetails["mid"] = {
 	getOffset = function()
 		return 0
 	end,
-	getStartOffset = function(totalIconX) 
+	getStartOffset = function(totalIconX)
 		local alignmentGap = IconController["midGap"]
 		return -totalIconX/2 + (alignmentGap/2)
 	end,
@@ -291,7 +291,7 @@ function IconController.updateTopbar()
 		topbarUpdating = true
 		runService.Heartbeat:Wait()
 		topbarUpdating = false
-		
+
 		for alignment, alignmentInfo in pairs(alignmentDetails) do
 			alignmentInfo.records = {}
 		end
@@ -374,7 +374,7 @@ function IconController.updateTopbar()
 				local oppositeAlignment = (alignment == "left" and "right") or "left"
 				local oppositeAlignmentInfo = alignmentDetails[oppositeAlignment]
 				local oppositeOverflowIcon = IconController.getIcon("_overflowIcon-"..oppositeAlignment)
-				
+
 				-- This determines whether any icons (from opposite or mid alignment) are overlapping with this alignment
 				local overflowBoundaryX = getBoundaryX(overflowIcon, alignment)
 				if overflowIcon.enabled then
@@ -472,9 +472,9 @@ function IconController.updateTopbar()
 							break
 						end
 					end
-				
+
 				else
-					
+
 					-- This checks to see if the lowest/highest (depending on left/right) ordered overlapping icon is no longer overlapping, removes from the dropdown, and repeats if valid
 					local winningOrder, winningOverlappedIcon
 					local totalOverlappingIcons = #overflowIcon.dropdownIcons
@@ -530,6 +530,7 @@ function IconController.updateTopbar()
 		end
 		return true
 	end)
+	return true
 end
 
 function IconController.setTopbarEnabled(bool, forceBool)
@@ -553,7 +554,7 @@ function IconController.setTopbarEnabled(bool, forceBool)
 				if controllerMenuOverride and controllerMenuOverride.Connected then
 					controllerMenuOverride:Disconnect()
 				end
-				
+
 				if hapticService:IsVibrationSupported(Enum.UserInputType.Gamepad1) and hapticService:IsMotorSupported(Enum.UserInputType.Gamepad1,Enum.VibrationMotor.Small) then
 					hapticService:SetMotor(Enum.UserInputType.Gamepad1,Enum.VibrationMotor.Small,1)
 					delay(0.2,function()
@@ -570,8 +571,8 @@ function IconController.setTopbarEnabled(bool, forceBool)
 					0.1,
 					true
 				)
-				
-				
+
+
 				local selectIcon
 				local targetOffset = 0
 				IconController:_updateSelectionGroup()
@@ -971,7 +972,7 @@ end
 -- BEHAVIOUR
 --Controller support
 coroutine.wrap(function()
-	
+
 	-- Create PC 'Enter Controller Mode' Icon
 	runService.Heartbeat:Wait() -- This is required to prevent an infinite recursion
 	local Icon = require(iconModule)
@@ -1077,9 +1078,9 @@ coroutine.wrap(function()
 		checkVoiceChatManuallyEnabled()
 
 	end)
-	
-	
-	
+
+
+
 
 
 	if not isStudio then

--- a/src/Icon/IconController.lua
+++ b/src/Icon/IconController.lua
@@ -7,7 +7,6 @@ local userInputService = game:GetService("UserInputService")
 local tweenService = game:GetService("TweenService")
 local players = game:GetService("Players")
 local VRService = game:GetService("VRService")
-local voiceChatService = game:GetService("VoiceChatService")
 local localizationService = game:GetService("LocalizationService")
 local iconModule = script.Parent
 local TopbarPlusReference = require(iconModule.TopbarPlusReference)
@@ -30,7 +29,6 @@ local cameraConnection
 local controllerMenuOverride
 local isStudio = runService:IsStudio()
 local localPlayer = players.LocalPlayer
-local voiceChatIsEnabledForUserAndWithinExperience = false
 local disableControllerOption = false
 local STUPID_CONTROLLER_OFFSET = 32
 
@@ -67,11 +65,6 @@ alignmentDetails["left"] = {
 	startScale = 0,
 	getOffset = function()
 		local offset = IconController.leftOffset
-		if checkTopbarEnabled() then
-			if voiceChatIsEnabledForUserAndWithinExperience and not isStudio then
-				offset += 43
-			end
-		end
 		return offset
 	end,
 	getStartOffset = function()
@@ -123,7 +116,6 @@ IconController.midGap = 12
 IconController.rightGap = 12
 IconController.leftOffset = 0
 IconController.rightOffset = 0
-IconController.voiceChatEnabled = nil
 IconController.mimicCoreGui = true
 IconController.healthbarDisabled = false
 IconController.activeButtonBCallbacks = 0
@@ -1044,36 +1036,6 @@ coroutine.wrap(function()
 			}
 		end
 	end
-
-
-
-
-
-	-- This checks if voice chat is enabled
-	task.defer(function()
-		local success, enabledForUser
-		while true do
-			success, enabledForUser = pcall(function() return voiceChatService:IsVoiceEnabledForUserIdAsync(localPlayer.UserId) end)
-			if success then
-				break
-			end
-			task.wait(1)
-		end
-		local function checkVoiceChatManuallyEnabled()
-			if IconController.voiceChatEnabled then
-				if success and enabledForUser then
-					voiceChatIsEnabledForUserAndWithinExperience = true
-					IconController.updateTopbar()
-				end
-			end
-		end
-		checkVoiceChatManuallyEnabled()
-
-	end)
-
-
-
-
 
 	if not isStudio then
 		local ownerId = game.CreatorId

--- a/src/Icon/Themes/Default.lua
+++ b/src/Icon/Themes/Default.lua
@@ -38,8 +38,8 @@ return {
         -- How items appear normally (i.e. when they're 'deselected')
         deselected = {
             iconBackgroundColor = Color3.fromRGB(0, 0, 0),
-            iconBackgroundTransparency = 0.5,
-            iconCornerRadius = UDim.new(0.25, 0),
+            iconBackgroundTransparency = 0.3,
+            iconCornerRadius = UDim.new(1, 0),
             iconGradientColor = ColorSequence.new(Color3.fromRGB(255, 255, 255)),
             iconGradientRotation = 0,
             iconImage = "",
@@ -49,9 +49,9 @@ return {
             iconImageRatio = 1,
             iconLabelYScale = 0.45,
             iconScale = UDim2.new(1, 0, 1, 0),
-            forcedIconSizeX = 32;
-            forcedIconSizeY = 32;
-            iconSize = UDim2.new(0, 32, 0, 32),
+            forcedIconSizeX = 44;
+            forcedIconSizeY = 44;
+            iconSize = UDim2.new(0, 44, 0, 44),
             iconOffset = UDim2.new(0, 0, 0, 0),
             iconText = "",
             iconTextColor = Color3.fromRGB(255, 255, 255),

--- a/src/Icon/Themes/Default.lua
+++ b/src/Icon/Themes/Default.lua
@@ -45,7 +45,7 @@ return {
             iconImage = "",
             iconImageColor =Color3.fromRGB(255, 255, 255),
             iconImageTransparency = 0,
-            iconImageYScale = 0.63,
+            iconImageYScale = 24/44, -- Roughly matches Roblox's icon scale
             iconImageRatio = 1,
             iconLabelYScale = 0.45,
             iconScale = UDim2.new(1, 0, 1, 0),

--- a/src/Icon/TopbarPlusGui.lua
+++ b/src/Icon/TopbarPlusGui.lua
@@ -4,6 +4,7 @@ topbarPlusGui.Enabled = true
 topbarPlusGui.DisplayOrder = 0
 topbarPlusGui.IgnoreGuiInset = true
 topbarPlusGui.ResetOnSpawn = false
+topbarPlusGui.ScreenInsets = Enum.ScreenInsets.TopbarSafeInsets
 topbarPlusGui.Name = "TopbarPlus"
 
 local activeItems = Instance.new("Folder")
@@ -14,7 +15,7 @@ local topbarContainer = Instance.new("Frame")
 topbarContainer.BackgroundTransparency = 1
 topbarContainer.Name = "TopbarContainer"
 topbarContainer.Position = UDim2.new(0, 0, 0, 0)
-topbarContainer.Size = UDim2.new(1, 0, 0, 36)
+topbarContainer.Size = UDim2.fromScale(1, 1)
 topbarContainer.Visible = true
 topbarContainer.ZIndex = 1
 topbarContainer.Parent = topbarPlusGui
@@ -23,7 +24,7 @@ topbarContainer.Active = false
 local iconContainer = Instance.new("Frame")
 iconContainer.BackgroundTransparency = 1
 iconContainer.Name = "IconContainer"
-iconContainer.Position = UDim2.new(0, 104, 0, 4)
+iconContainer.Position = UDim2.fromScale(0, 0)
 iconContainer.Visible = false
 iconContainer.ZIndex = 1
 iconContainer.Parent = topbarContainer
@@ -212,7 +213,7 @@ tipFrame.Active = false
 
 local tipCorner = Instance.new("UICorner")
 tipCorner.Name = "TipCorner"
-tipCorner.CornerRadius = UDim.new(0.25,0)
+tipCorner.CornerRadius = UDim.new(.25, 0)
 tipCorner.Parent = tipFrame
 
 local tipLabel = Instance.new("TextLabel")

--- a/src/Icon/VERSION.lua
+++ b/src/Icon/VERSION.lua
@@ -1,1 +1,1 @@
-return "v2.9.1"
+return "v2.11.0"

--- a/src/Icon/init.lua
+++ b/src/Icon/init.lua
@@ -1758,7 +1758,7 @@ function Icon:displayCaption(bool)
 	end
 	local iconContainer = self.instances.iconContainer
 	local captionContainer = self.instances.captionContainer
-	local newPos = UDim2.new(0, iconContainer.AbsolutePosition.X+iconContainer.AbsoluteSize.X/2-captionContainer.AbsoluteSize.X/2, 0, iconContainer.AbsolutePosition.Y+(iconContainer.AbsoluteSize.Y*2)+yOffset)
+	local newPos = UDim2.new(0, iconContainer.Position.X.Offset+iconContainer.AbsoluteSize.X/2-captionContainer.AbsoluteSize.X/2, 0, iconContainer.Position.Y.Offset+(iconContainer.AbsoluteSize.Y)+yOffset)
 	captionContainer.Position = newPos
 
 	-- Determine caption visibility

--- a/src/Icon/init.lua
+++ b/src/Icon/init.lua
@@ -1309,7 +1309,9 @@ function Icon:_getContentText(text)
 end
 
 function Icon:_updateIconSize(_, iconState)
-	if self._destroyed then return end
+	if self._destroyed or self._updatingIconSize then return end
+	self._updatingIconSize = true
+
 	-- This is responsible for handling the appearance and size of the icons label and image, in additon to its own size
 	local X_MARGIN = 12
 	local X_GAP = 8
@@ -1388,7 +1390,6 @@ function Icon:_updateIconSize(_, iconState)
 	end
 	if desiredCellWidth then
 		if not self._updatingIconSize then
-			self._updatingIconSize = true
 			local widthScale = (cellSizeXScale > 0 and cellSizeXScale) or 0
 			local widthOffset = (cellSizeXScale > 0 and 0) or math.clamp(desiredCellWidth, minCellWidth, maxCellWidth)
 			self:set("iconSize", UDim2.new(widthScale, widthOffset, values.iconSize.Y.Scale, values.iconSize.Y.Offset), iconState, "_ignorePrevious")
@@ -1407,7 +1408,6 @@ function Icon:_updateIconSize(_, iconState)
 				end
 			end
 
-			self._updatingIconSize = false
 		end
 	end
 	self:set("iconLabelTextSize", labelHeight, iconState)

--- a/src/Icon/init.lua
+++ b/src/Icon/init.lua
@@ -1,5 +1,4 @@
 -- LOCAL
-local LocalizationService = game:GetService("LocalizationService")
 local tweenService = game:GetService("TweenService")
 local debris = game:GetService("Debris")
 local userInputService = game:GetService("UserInputService")
@@ -8,10 +7,7 @@ local runService = game:GetService("RunService")
 local textService = game:GetService("TextService")
 local starterGui = game:GetService("StarterGui")
 local guiService = game:GetService("GuiService")
-local localizationService = game:GetService("LocalizationService")
-local playersService = game:GetService("Players")
 
-local localPlayer = playersService.LocalPlayer
 local iconModule = script
 
 local IconController = require(iconModule.IconController)
@@ -37,10 +33,6 @@ local Icon = {}
 for _,s in ipairs(script:GetChildren()) do
     if not s:IsA("ModuleScript") then continue end
     Icon[s.Name] = s
-end
-
-function Icon.setVoiceChatEnabled(bool: boolean)
-	IconController.voiceChatEnabled = bool
 end
 
 Icon.__index = Icon

--- a/src/Icon/init.lua
+++ b/src/Icon/init.lua
@@ -405,7 +405,7 @@ function Icon.new()
 	self.dropdownOpen = false
 	self.menuOpen = false
 	self.locked = false
-	self.topPadding = UDim.new(0, 12)
+	self.topPadding = UDim.new(0, 6)
 	self.targetPosition = nil
 	self.toggleItems = {}
 	self.lockedSettings = {}
@@ -1485,7 +1485,7 @@ function Icon:autoDeselect(bool)
 end
 
 function Icon:setTopPadding(offset, scale)
-	local newOffset = offset or 4
+	local newOffset = offset or 6
 	local newScale = scale or 0
 	self.topPadding = UDim.new(newScale, newOffset)
 	self.updated:Fire()

--- a/src/Icon/init.lua
+++ b/src/Icon/init.lua
@@ -54,7 +54,7 @@ local DEFAULT_FORCED_GROUP_VALUES = {}
 
 
 -- CONSTRUCTORS
-function Icon.new()	
+function Icon.new()
 	local self = {}
 	setmetatable(self, Icon)
 
@@ -247,7 +247,7 @@ function Icon.new()
 				isDeselected = not self.dropdownOpen
 			end
 			local isSpecialPressing = self._longPressing or self._rightClicking
-			if self._tappingAway or (isDeselected and not isSpecialPressing) or (isSpecialPressing and self.dropdownOpen) then 
+			if self._tappingAway or (isDeselected and not isSpecialPressing) or (isSpecialPressing and self.dropdownOpen) then
 				local dropdownSize = self:get("dropdownSize")
 				local XOffset = (dropdownSize and dropdownSize.X.Offset/1) or 0
 				newValue = UDim2.new(0, XOffset, 0, 0)
@@ -275,9 +275,7 @@ function Icon.new()
 				--dropdownContainer.ClipsDescendants = not self.dropdownOpen
 			end)
 			tween:Play()
-			if isOpen then
-				--dropdownFrame.CanvasPosition = self._dropdownCanvasPos
-			else
+			if not isOpen then
 				self._dropdownCanvasPos = dropdownFrame.CanvasPosition
 			end
 			dropdownFrame.ScrollingEnabled = isOpen -- It's important scrolling is only enabled when the dropdown is visible otherwise it could block the scrolling behaviour of other icons
@@ -296,7 +294,7 @@ function Icon.new()
 				isDeselected = not self.menuOpen
 			end
 			local isSpecialPressing = self._longPressing or self._rightClicking
-			if self._tappingAway or (isDeselected and not isSpecialPressing) or (isSpecialPressing and self.menuOpen) then 
+			if self._tappingAway or (isDeselected and not isSpecialPressing) or (isSpecialPressing and self.menuOpen) then
 				local menuSize = self:get("menuSize")
 				local YOffset = (menuSize and menuSize.Y.Offset/1) or 0
 				newValue = UDim2.new(0, 0, 0, YOffset)
@@ -312,7 +310,6 @@ function Icon.new()
 			local connection
 			connection = tween.Completed:Connect(function()
 				connection:Disconnect()
-				--menuContainer.ClipsDescendants = not self.menuOpen
 			end)
 			tween:Play()
 			if isOpen then
@@ -348,10 +345,9 @@ function Icon.new()
 				self._uniqueSettings[uniqueCat] = uniqueCatArray
 				self._uniqueSettingsDictionary[settingName] = uniqueBehaviours[uniqueCat]
 			end
-			--
 		end
 	end
-	
+
 	-- Signals (events)
 	self.updated = maid:give(Signal.new())
 	self.selected = maid:give(Signal.new())
@@ -369,7 +365,7 @@ function Icon.new()
 	self.notified = maid:give(Signal.new())
 	self._endNotices = maid:give(Signal.new())
 	self._ignoreClippingChanged = maid:give(Signal.new())
-	
+
 	-- Connections
 	-- This enables us to chain icons and features like menus and dropdowns together without them being hidden by parent frame with ClipsDescendants enabled
 	local function setFeatureChange(featureName, value)
@@ -417,13 +413,13 @@ function Icon.new()
 	self.dropdownOpen = false
 	self.menuOpen = false
 	self.locked = false
-	self.topPadding = UDim.new(0, 4)
+	self.topPadding = UDim.new(0, 12)
 	self.targetPosition = nil
 	self.toggleItems = {}
 	self.lockedSettings = {}
 	self.UID = httpService:GenerateGUID(true)
 	self.blockBackBehaviourChecks = {}
-	
+
 	-- Private Properties
 	self._draggingFinger = false
 	self._updatingIconSize = true
@@ -431,7 +427,7 @@ function Icon.new()
 	self._previousMenuOpen = false
 	self._bindedToggleKeys = {}
 	self._bindedEvents = {}
-	
+
 	-- Apply start values
 	self:setName("UnnamedIcon")
 	self:setTheme(DEFAULT_THEME, true)
@@ -513,7 +509,7 @@ function Icon.new()
 		end
 		--
 	end)
-	
+
 	-- hoverStarted and hoverEnded triggers and actions
 	-- these are triggered when a mouse enters/leaves the icon with a mouse, is highlighted with
 	-- a controller selection box, or dragged over with a touchpad
@@ -594,7 +590,7 @@ function Icon.new()
 	self._updatingIconSize = false
 	self:_updateIconSize()
 	IconController.iconAdded:Fire(self)
-	
+
 	return self
 end
 
@@ -614,7 +610,7 @@ function Icon.mimic(coreIconToMimic)
 		icon:setImage("rbxasset://textures/ui/TopBar/chatOn.png", "selected")
 		icon:setImageYScale(0.625)
 		-- Since roblox's core gui api sucks melons I reverted to listening for signals within the chat modules
-		-- unfortunately however they've just gone and removed *these* signals therefore 
+		-- unfortunately however they've just gone and removed *these* signals therefore
 		-- this mimic chat and similar features are now impossible to recreate accurately, so I'm disabling for now
 		-- ill go ahead and post a feature request; fingers crossed we get something by the next decade
 
@@ -781,7 +777,7 @@ function Icon:set(settingName, value, iconState, setAdditional)
 			callMethod(self, value, iconState)
 		end
 	end
-	
+
 	-- Call any signals present
 	if settingDetail.callSignals then
 		for _, callSignal in pairs(settingDetail.callSignals) do
@@ -828,7 +824,7 @@ function Icon:get(settingName, iconState, getAdditional)
 		if valueToReturn == nil then
 			valueToReturn = settingDetail.values[toggleState]
 		end
-	
+
 	else
 		if additionalValueToReturn == nil then
 			additionalValueToReturn = type(getAdditional) == "string" and settingDetail.additionalValues[getAdditional]
@@ -1133,7 +1129,7 @@ function Icon:notify(clearNoticeEvent, noticeId)
 		if self._parentIcon then
 			self._parentIcon:notify(clearNoticeEvent)
 		end
-		
+
 		local notifComplete = Signal.new()
 		local endEvent = self._endNotices:Connect(function()
 			notifComplete:Fire()
@@ -1141,7 +1137,7 @@ function Icon:notify(clearNoticeEvent, noticeId)
 		local customEvent = clearNoticeEvent:Connect(function()
 			notifComplete:Fire()
 		end)
-		
+
 		noticeId = noticeId or httpService:GenerateGUID(true)
 		self.notices[noticeId] = {
 			completeSignal = notifComplete,
@@ -1152,11 +1148,11 @@ function Icon:notify(clearNoticeEvent, noticeId)
 
 		self.notified:Fire(noticeId)
 		notifComplete:Wait()
-		
+
 		endEvent:Disconnect()
 		customEvent:Disconnect()
 		notifComplete:Disconnect()
-		
+
 		self.totalNotices -= 1
 		self.notices[noticeId] = nil
 		self:_updateNotice()
@@ -1256,7 +1252,7 @@ function Icon:setLabelYScale(YScale, iconState)
 	local newYScale = tonumber(YScale) or 0.45
 	return self:set("iconLabelYScale", newYScale, iconState)
 end
-	
+
 function Icon:setBaseZIndex(ZIndex, iconState)
 	local newBaseZIndex = tonumber(ZIndex) or 1
 	return self:set("baseZIndex", newBaseZIndex, iconState)
@@ -1359,13 +1355,13 @@ function Icon:_updateIconSize(_, iconState)
 	local iconContentText = self:_getContentText(values.iconText)
 	local labelWidth = textService:GetTextSize(iconContentText, labelHeight, values.iconFont, Vector2.new(10000, labelHeight)).X
 	local imageWidth = cellHeight * values.iconImageYScale * values.iconImageRatio
-	
+
 	local usingImage = values.iconImage ~= ""
 	local usingText = values.iconText ~= ""
 	local notifPosYScale = 0.5
 	local desiredCellWidth
 	local preventClippingOffset = labelHeight/2
-	
+
 	if usingImage and not usingText then
 		desiredCellWidth = 0
 		notifPosYScale = 0.45
@@ -1585,7 +1581,7 @@ function Icon:setTip(text)
 	self.instances.tipFrame.Parent = (isVisible and activeItems) or self.instances.iconContainer
 	self._maid.tipFrame = self.instances.tipFrame
 	self:_updateTipSize()
-	
+
 	local tipMaid = Maid.new()
 	self._maid.tipMaid = tipMaid
 	if isVisible then
@@ -1659,11 +1655,7 @@ function Icon:displayTip(bool)
 				newX = math.clamp(desiredX, minX, maxX)
 				newY = math.clamp(desiredY, minY, maxY)
 			end
-			--local difX = tipFrame.AbsolutePosition.X - tipFrame.Position.X.Offset
-			--local difY = tipFrame.AbsolutePosition.Y - tipFrame.Position.Y.Offset
-			--local globalX = newX - difX
-			--local globalY = newY - difY
-			--tipFrame.Position = UDim2.new(0, globalX, 0, globalY-55)
+
 			tipFrame.Position = UDim2.new(0, newX, 0, newY-20)
 		end
 		local cursorLocation = userInputService:GetMouseLocation()
@@ -1759,7 +1751,7 @@ end
 function Icon:displayCaption(bool)
 	if userInputService.TouchEnabled and not self._draggingFinger then return end
 	local yOffset = 8
-	
+
 	-- Determine caption position
 	if self._draggingFinger then
 		yOffset = yOffset + THUMB_OFFSET
@@ -1801,7 +1793,7 @@ function Icon:join(parentIcon, featureName, dontUpdate)
 		parentIcon:notify(noticeDetail.clearNoticeEvent, noticeId)
 		--parentIcon:notify(noticeDetail.completeSignal, noticeId)
 	end
-	
+
 	if featureName == "dropdown" then
 		local squareCorners = parentIcon:get("dropdownSquareCorners")
 		self:set("iconSize", UDim2.new(1, 0, 0, self:get("iconSize", "deselected").Y.Offset), "deselected", beforeName)
@@ -1967,7 +1959,7 @@ function Icon:_updateDropdown()
 		scrollBarThickness = self:get("dropdownScrollBarThickness") or "_NIL",
 	}
 	for k, v in pairs(values) do if v == "_NIL" then return end end
-	
+
 	local YPadding = values.padding.Offset
 	local dropdownContainer = self.instances.dropdownContainer
 	local dropdownFrame = self.instances.dropdownFrame
@@ -2066,7 +2058,7 @@ function Icon:_getMenuDirection()
 	local direction = (self:get("menuDirection") or "_NIL"):lower()
 	local alignment = (self:get("alignment") or "_NIL"):lower()
 	if direction ~= "left" and direction ~= "right" then
-		direction = (alignment == "left" and "right") or "left" 
+		direction = (alignment == "left" and "right") or "left"
 	end
 	return direction
 end
@@ -2079,7 +2071,7 @@ function Icon:_updateMenu()
 		scrollBarThickness = self:get("menuScrollBarThickness") or "_NIL",
 	}
 	for k, v in pairs(values) do if v == "_NIL" then return end end
-	
+
 	local XPadding = IconController[values.iconAlignment.."Gap"]--12
 	local menuContainer = self.instances.menuContainer
 	local menuFrame = self.instances.menuFrame

--- a/src/Icon/init.lua
+++ b/src/Icon/init.lua
@@ -1627,11 +1627,12 @@ function Icon:displayTip(bool)
 		-- When the user moves their cursor/finger, update tip to match the position
 		local function updateTipPositon(x, y)
 			local newX = x
+			local guiInset = guiService.TopbarInset
+			newX = newX - guiInset.Min.X
 			local newY = y
 			local camera = workspace.CurrentCamera
 			local viewportSize = camera and camera.ViewportSize
 			if userInputService.TouchEnabled then
-				--tipFrame.AnchorPoint = Vector2.new(0.5, 0.5)
 				local desiredX = newX - tipFrame.Size.X.Offset/2
 				local minX = 0
 				local maxX = viewportSize.X - tipFrame.Size.X.Offset

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bebopdevelopmentstudios/topbarplus"
-version = "2.10.0"
+version = "2.11.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
This PR adds support for the new [Experience Controls](https://devforum.roblox.com/t/studio-beta-for-experience-controls-available-now/2567355).
Specifically, this is three things:
1. Removing the logic for the voice chat offset, since this is now part of the menu
![image](https://github.com/BebopDevelopmentStudios/TopbarPlus/assets/42497624/488c5af9-3b16-4a9b-9a16-40fec992907b)
2. Changing the TopbarGui gui to make use of `TopbarSafeInsets`
3. Offsetting the icons based on the device type (6px on mobile, 12px on desktop)


Examples:
- Mobile
![image](https://github.com/BebopDevelopmentStudios/TopbarPlus/assets/42497624/d241f89c-5841-4f80-b6b7-8af308e9d002)
- Desktop
![image](https://github.com/BebopDevelopmentStudios/TopbarPlus/assets/42497624/9293cff8-6e0a-4071-a52c-1c6988fa5e05)